### PR TITLE
Complete Observable after finding the first episode matching the clicked ID

### DIFF
--- a/app/src/main/java/com/rainerlang/tvmazeclient/ui/schedule_view/SchedulePresenter.java
+++ b/app/src/main/java/com/rainerlang/tvmazeclient/ui/schedule_view/SchedulePresenter.java
@@ -28,7 +28,7 @@ class SchedulePresenter extends BasePresenter<ScheduleMvp.View> implements Sched
   public void onItemClicked(ScheduleItemView scheduleItemView, int position) {
     manageSubscription(
         Observable.from(episodes)
-            .filter(episode -> episode.id()==scheduleItemView.getModel().id())
+            .takeFirst(episode -> episode.id()==scheduleItemView.getModel().id())
             .compose(RxHelper.applySchedulersIo())
             .subscribe(episode -> sendToView(view -> view.startEpisodeActivity(episode))));
   }


### PR DESCRIPTION
This is an optimisation over the existing implementation (which takes O(n) time) - after the improvement it is still O(n), but should now be twice as fast on average. However I would still opt for going with a HashMap which gives us O(1) access times and no overhead building an Observable chain. Surely constructing the HashMap is a bit more expensive than an ArrayList, but that is done just once after loading.